### PR TITLE
Add story aspect ratio layout and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Fishily Quickshot is a lightweight React app for generating social-ready screens
 
 - editable title and subtitle
 - configurable background color (hex)
-- square (`1:1`) and portrait (`4:5`) layouts
-- phone placement modes (`Phone bottom` / `Phone top`)
+- square (`1:1`), portrait (`4:5`), and story (`9:16`) layouts
+- mirrored phone placement modes (`Phone bottom` / `Phone top`)
 - image upload and PNG export
 
 ## Tech stack

--- a/e2e/ui-smoke.spec.ts
+++ b/e2e/ui-smoke.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 
 type Scenario = {
   name: string;
-  aspectLabel: "Square (1:1)" | "Portrait (4:5)";
+  aspectLabel: "Square (1:1)" | "Portrait (4:5)" | "Story (9:16)";
   typeLabel: "Phone bottom" | "Phone top";
   backgroundHex: string;
 };
@@ -10,9 +10,13 @@ type Scenario = {
 type ScenarioMetrics = {
   scenario: string;
   viewBox: string | null;
+  canvasWidth: number | null;
+  canvasHeight: number | null;
   titleY: number | null;
   subtitleY: number | null;
+  phoneX: number | null;
   phoneY: number | null;
+  phoneWidth: number | null;
   phoneHeight: number | null;
   preserveAspectRatio: string | null;
   backgroundFill: string | null;
@@ -48,6 +52,18 @@ const SCENARIOS: Scenario[] = [
     typeLabel: "Phone top",
     backgroundHex: "#000000",
   },
+  {
+    name: "story-bottom-light",
+    aspectLabel: "Story (9:16)",
+    typeLabel: "Phone bottom",
+    backgroundHex: "#f9f9ff",
+  },
+  {
+    name: "story-top-light",
+    aspectLabel: "Story (9:16)",
+    typeLabel: "Phone top",
+    backgroundHex: "#f9f9ff",
+  },
 ];
 
 async function applyScenario(page: Page, scenario: Scenario) {
@@ -75,13 +91,19 @@ async function readScenarioMetrics(
     const titleText = svg.querySelector('text[fill="#000000"]');
     const subtitleText = svg.querySelector('text[fill="#707070"]');
     const phoneContent = svg.querySelector("image, rect[fill='#151518']");
+    const viewBox = svg.getAttribute("viewBox");
+    const [, , width, height] = viewBox?.split(/\s+/).map(Number) ?? [];
 
     return {
       scenario,
-      viewBox: svg.getAttribute("viewBox"),
+      viewBox,
+      canvasWidth: Number.isFinite(width) ? width : null,
+      canvasHeight: Number.isFinite(height) ? height : null,
       titleY: titleText ? Number(titleText.getAttribute("y")) : null,
       subtitleY: subtitleText ? Number(subtitleText.getAttribute("y")) : null,
+      phoneX: phoneContent ? Number(phoneContent.getAttribute("x")) : null,
       phoneY: phoneContent ? Number(phoneContent.getAttribute("y")) : null,
+      phoneWidth: phoneContent ? Number(phoneContent.getAttribute("width")) : null,
       phoneHeight: phoneContent ? Number(phoneContent.getAttribute("height")) : null,
       preserveAspectRatio: phoneContent
         ? phoneContent.getAttribute("preserveAspectRatio")
@@ -194,6 +216,55 @@ test("visual scenario matrix artifacts for comparison", async ({ page }, testInf
   expect(metrics).toHaveLength(SCENARIOS.length);
   expect(metrics.every((item) => item.viewBox !== null)).toBe(true);
   expect(metrics.every((item) => item.phoneHeight !== null)).toBe(true);
+});
+
+test("story aspect keeps text above the phone and mirrors vertically", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/");
+
+  const bottom = SCENARIOS.find((scenario) => scenario.name === "story-bottom-light");
+  const top = SCENARIOS.find((scenario) => scenario.name === "story-top-light");
+
+  expect(bottom).toBeDefined();
+  expect(top).toBeDefined();
+
+  await applyScenario(page, bottom!);
+  const bottomMetrics = await readScenarioMetrics(page, bottom!.name);
+  await page.locator(".svg-square").screenshot({
+    path: testInfo.outputPath("story-bottom-template.png"),
+  });
+
+  await applyScenario(page, top!);
+  const topMetrics = await readScenarioMetrics(page, top!.name);
+  await page.locator(".svg-square").screenshot({
+    path: testInfo.outputPath("story-top-template.png"),
+  });
+
+  expect(bottomMetrics.viewBox).toBe("0 0 1080 1920");
+  expect(topMetrics.viewBox).toBe("0 0 1080 1920");
+  expect(bottomMetrics.canvasWidth).toBe(1080);
+  expect(bottomMetrics.canvasHeight).toBe(1920);
+  expect(bottomMetrics.titleY).not.toBeNull();
+  expect(bottomMetrics.subtitleY).not.toBeNull();
+  expect(bottomMetrics.phoneY).not.toBeNull();
+  expect(bottomMetrics.phoneHeight).not.toBeNull();
+  expect(bottomMetrics.phoneX).not.toBeNull();
+  expect(bottomMetrics.phoneWidth).not.toBeNull();
+  expect(bottomMetrics.subtitleY!).toBeLessThan(bottomMetrics.phoneY!);
+  expect(bottomMetrics.phoneY! + bottomMetrics.phoneHeight!).toBeGreaterThan(
+    bottomMetrics.canvasHeight!,
+  );
+  expect(
+    Math.abs(
+      (bottomMetrics.phoneX! + bottomMetrics.phoneWidth! / 2) -
+        bottomMetrics.canvasWidth! / 2,
+    ),
+  ).toBeLessThan(1);
+  expect(topMetrics.phoneY!).toBeLessThan(bottomMetrics.phoneY!);
+  expect(topMetrics.titleY!).toBeGreaterThan(bottomMetrics.titleY!);
+  expect(bottomMetrics.preserveAspectRatio).toBe("xMidYMin slice");
+  expect(topMetrics.preserveAspectRatio).toBe("xMidYMax slice");
 });
 
 test("dark mode updates app chrome without changing SVG content colors", async ({

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -63,6 +63,9 @@ describe("App", () => {
     expect(screen.getByLabelText("Subtitle")).toBeInTheDocument();
     expect(screen.getByLabelText("Custom background hex")).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Square (1:1)" })).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "Story (9:16)" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Phone bottom" })).toBeChecked();
     expect(
       screen.getByRole("button", { name: "Export image (PNG)" }),
@@ -142,6 +145,13 @@ describe("App", () => {
     );
 
     await user.click(screen.getByRole("radio", { name: "Phone top" }));
+    expect(container.querySelector(".svg-square image")).toHaveAttribute(
+      "preserveAspectRatio",
+      "xMidYMax slice",
+    );
+
+    await user.click(screen.getByRole("radio", { name: "Story (9:16)" }));
+    expect(getSvg(container).getAttribute("viewBox")).toBe("0 0 1080 1920");
     expect(container.querySelector(".svg-square image")).toHaveAttribute(
       "preserveAspectRatio",
       "xMidYMax slice",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,6 +207,17 @@ export default function App() {
               />
               <span className="switch__label">Portrait (4:5)</span>
             </label>
+
+            <label className="switch__option">
+              <input
+                type="radio"
+                name="aspect-ratio"
+                value="story"
+                checked={aspect === "story"}
+                onChange={() => setAspect("story")}
+              />
+              <span className="switch__label">Story (9:16)</span>
+            </label>
           </fieldset>
 
           <fieldset className="switch">

--- a/src/ScreenshotTemplate.tsx
+++ b/src/ScreenshotTemplate.tsx
@@ -1,6 +1,6 @@
 import { useId, useMemo, type Ref } from "react";
 
-export type Aspect = "square" | "portrait";
+export type Aspect = "square" | "portrait" | "story";
 export type ScreenshotType = "top" | "bottom";
 
 export type ScreenshotTemplateProps = {
@@ -13,19 +13,76 @@ export type ScreenshotTemplateProps = {
   svgRef?: Ref<SVGSVGElement>;
 };
 
-const SIZES: Record<Aspect, { w: number; h: number }> = {
-  square: { w: 1080, h: 1080 },
-  portrait: { w: 1080, h: 1350 },
+type ScaleRange = {
+  scale: number;
+  min: number;
+  max: number;
 };
 
-const PHONE_WIDTH_BOOST_BY_ASPECT: Record<Aspect, number> = {
-  square: 1.26,
-  portrait: 1.1,
+type GapScaleRange = ScaleRange & {
+  offset: number;
 };
+
+type AspectLayout = {
+  size: { w: number; h: number };
+  phoneWidthBoost: number;
+  phoneScale: number;
+  titleFontSize: ScaleRange;
+  textEdgeInset: ScaleRange;
+  hiddenEdge: ScaleRange;
+  titleSubtitleGap: ScaleRange;
+  sectionGap: GapScaleRange;
+  textShiftDown: ScaleRange;
+  minTextPhoneGap: ScaleRange;
+};
+
+const ASPECT_LAYOUTS: Record<Aspect, AspectLayout> = {
+  square: {
+    size: { w: 1080, h: 1080 },
+    phoneWidthBoost: 1.26,
+    phoneScale: 1,
+    titleFontSize: { scale: 0.05, min: 32, max: 58 },
+    textEdgeInset: { scale: 0.02, min: 14, max: 32 },
+    hiddenEdge: { scale: 0.018, min: 12, max: 28 },
+    titleSubtitleGap: { scale: 1.02, min: 34, max: 64 },
+    sectionGap: { scale: 0.78, min: 24, max: 46, offset: 18 },
+    textShiftDown: { scale: 0.012, min: 8, max: 18 },
+    minTextPhoneGap: { scale: 0.72, min: 22, max: 40 },
+  },
+  portrait: {
+    size: { w: 1080, h: 1350 },
+    phoneWidthBoost: 1.1,
+    phoneScale: 1,
+    titleFontSize: { scale: 0.05, min: 32, max: 58 },
+    textEdgeInset: { scale: 0.02, min: 14, max: 32 },
+    hiddenEdge: { scale: 0.018, min: 12, max: 28 },
+    titleSubtitleGap: { scale: 1.02, min: 34, max: 64 },
+    sectionGap: { scale: 0.78, min: 24, max: 46, offset: 18 },
+    textShiftDown: { scale: 0.012, min: 8, max: 18 },
+    minTextPhoneGap: { scale: 0.72, min: 22, max: 40 },
+  },
+  story: {
+    size: { w: 1080, h: 1920 },
+    phoneWidthBoost: 1.04,
+    phoneScale: 0.950309,
+    titleFontSize: { scale: 0.04656, min: 43, max: 81 },
+    textEdgeInset: { scale: 0.028518, min: 38, max: 69 },
+    hiddenEdge: { scale: 0.072, min: 96, max: 144 },
+    titleSubtitleGap: { scale: 0.98, min: 62, max: 92 },
+    sectionGap: { scale: 0.03, min: 40, max: 68, offset: 18 },
+    textShiftDown: { scale: 0, min: 0, max: 0 },
+    minTextPhoneGap: { scale: 0.82, min: 64, max: 96 },
+  },
+};
+
 const DEVICE_ASPECT_RATIO = 2.16;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function resolveScale(value: number, range: ScaleRange): number {
+  return clamp(value * range.scale, range.min, range.max);
 }
 
 function dTopRoundedBottomSquare(
@@ -73,28 +130,38 @@ export function ScreenshotTemplate({
   backgroundColor = "#f9f9ff",
   svgRef,
 }: ScreenshotTemplateProps) {
-  const { w: W, h: H } = SIZES[aspect];
+  const layout = ASPECT_LAYOUTS[aspect];
+  const { w: W, h: H } = layout.size;
 
   const geometry = useMemo(() => {
-    const titleFontSize = clamp(H * 0.05, 32, 58);
+    const titleFontSize = resolveScale(H, layout.titleFontSize);
     const subtitleFontSize = titleFontSize;
-    const textEdgeInset = clamp(H * 0.02, 14, 32);
-    const hiddenEdge = clamp(H * 0.018, 12, 28);
-    const titleSubtitleGap = clamp(titleFontSize * 1.02, 34, 64);
+    const textEdgeInset = resolveScale(H, layout.textEdgeInset);
+    const hiddenEdge = resolveScale(H, layout.hiddenEdge);
+    const titleSubtitleGap = clamp(
+      titleFontSize * layout.titleSubtitleGap.scale,
+      layout.titleSubtitleGap.min,
+      layout.titleSubtitleGap.max,
+    );
     const subtitleDescender = subtitleFontSize * 0.28;
     const textBlockHeight =
       titleFontSize + titleSubtitleGap + subtitleDescender;
-    const sectionGap = clamp(titleFontSize * 0.78, 24, 46) + 18;
-    const textShiftDown = clamp(H * 0.012, 8, 18);
+    const sectionGap =
+      clamp(
+        titleFontSize * layout.sectionGap.scale,
+        layout.sectionGap.min,
+        layout.sectionGap.max,
+      ) + layout.sectionGap.offset;
+    const textShiftDown = resolveScale(H, layout.textShiftDown);
 
-    const phoneWidthBoost = PHONE_WIDTH_BOOST_BY_ASPECT[aspect];
     const visiblePhoneHeight =
       H - textEdgeInset * 2 - textBlockHeight - sectionGap;
-    const screenH = visiblePhoneHeight + hiddenEdge;
-    const screenW = (screenH / DEVICE_ASPECT_RATIO) * phoneWidthBoost;
+    const scaledVisiblePhoneHeight = visiblePhoneHeight * layout.phoneScale;
+    const screenH = scaledVisiblePhoneHeight + hiddenEdge;
+    const screenW = (screenH / DEVICE_ASPECT_RATIO) * layout.phoneWidthBoost;
     const screenX = W / 2 - screenW / 2;
 
-    const baseScreenYBottom = H - visiblePhoneHeight;
+    const baseScreenYBottom = H - scaledVisiblePhoneHeight;
     const topBandEnd = baseScreenYBottom - sectionGap;
     const topBandHeight = Math.max(0, topBandEnd - textEdgeInset);
     const textTopYBottom =
@@ -104,7 +171,11 @@ export function ScreenshotTemplate({
     const titleYBottom = textTopYBottom + titleFontSize;
     const subtitleYBottom = titleYBottom + titleSubtitleGap;
     const subtitleBottomY = subtitleYBottom + subtitleDescender;
-    const minBottomTextPhoneGap = clamp(titleFontSize * 0.72, 22, 40);
+    const minBottomTextPhoneGap = clamp(
+      titleFontSize * layout.minTextPhoneGap.scale,
+      layout.minTextPhoneGap.min,
+      layout.minTextPhoneGap.max,
+    );
     const adjustedScreenYBottom = Math.max(
       baseScreenYBottom,
       subtitleBottomY + minBottomTextPhoneGap,
@@ -149,7 +220,7 @@ export function ScreenshotTemplate({
       outerStrokeWidth,
       imageBleed,
     };
-  }, [W, H, aspect, type]);
+  }, [W, H, layout, type]);
 
   const clipId = useId();
   const shadowId = useId();

--- a/src/index.css
+++ b/src/index.css
@@ -253,6 +253,7 @@ body {
 .switch__option {
   position: relative;
   flex: 1;
+  display: flex;
 }
 
 .switch__option input[type="radio"] {
@@ -263,13 +264,17 @@ body {
 }
 
 .switch__label {
-  display: block;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
   border: var(--qs-border);
   border-radius: var(--qs-radius);
   padding: 0.6em var(--qs-space-control-x);
   font-size: 16px;
   font-weight: 400;
   text-align: center;
+  line-height: 1.2;
   background: transparent;
   color: var(--qs-color-text);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add story (9:16) aspect option plus mirrored placement copy in README and UI
- extend template geometry calculations to support the taller layout and adjust controls styling
- cover the story flow with updated unit and Playwright smoke tests for layout metrics

## Testing
- Not run (not requested)